### PR TITLE
Include cutthroats in the visible threat calculation when they are in range

### DIFF
--- a/ecs/processors/threatprocessor.py
+++ b/ecs/processors/threatprocessor.py
@@ -19,7 +19,7 @@ class ThreatProcessor(Processor):
                 player.visible_threat = 0
                 player.actual_threat = 0
 
-                for entity, (monster, visible, position) in self.world.get_components(Monster, Visible, Position):
+                for entity, (monster, _, position) in self.world.get_components(Monster, Visible, Position):
                     distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
                     in_range = 1 <= distance <= len(monster.threat)
 

--- a/ecs/processors/threatprocessor.py
+++ b/ecs/processors/threatprocessor.py
@@ -1,4 +1,4 @@
-from esper import Processor
+from esper import Processor, World
 
 from constants import DijkstraMap, MAX_THREAT
 from ecs.components.assassin import Assassin
@@ -12,22 +12,23 @@ from ecs.components.visible import Visible
 
 class ThreatProcessor(Processor):
     def process(self):
+        self.world: World
+
         for _, game_map in self.world.get_component(Map):
             for player_entity, player in self.world.get_component(Player):
-
                 player.visible_threat = 0
                 player.actual_threat = 0
 
                 for entity, (monster, visible, position) in self.world.get_components(Monster, Visible, Position):
-                    if self.world.has_component(entity, Blinded):
-                        continue
+                    distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
+                    in_range = 1 <= distance <= len(monster.threat)
 
-                    if not self.world.has_component(entity, Assassin):
-                        threat = max(0, max(monster.threat) - player.defend)
+                    if in_range or not self.world.has_component(entity, Assassin):
+                        threat = max(monster.threat)
+                        threat = max(0, threat - player.defend)
                         player.visible_threat += threat
 
-                    distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
-                    if 1 <= distance <= len(monster.threat):
+                    if in_range and not self.world.has_component(entity, Blinded):
                         threat = monster.threat[distance - 1]
                         threat = max(0, threat - player.defend)
                         player.actual_threat += threat


### PR DESCRIPTION
Address Issue #2. Update ThreatProcessor to include cutthroats in the visible threat calculation when they are in range.

Change has been confirmed by spot check. In the example, there is 7 visible threat due to:
- 3 threat from three soldiers
- 4 threat from cutthroat

![issue2](https://user-images.githubusercontent.com/37474737/77530654-98b82000-6e89-11ea-9505-150101e0ff58.png)
