### PR TITLE
Update fire scroll targeting

### DIFF
--- a/ecs/components/monster.py
+++ b/ecs/components/monster.py
@@ -10,5 +10,5 @@ class Monster:
     health: int = 1
     defend: int = 1
 
-    cur_threat: int = 0
-    max_threat: int = 0
+    visible_threat: int = 0
+    actual_threat: int = 0

--- a/ecs/components/monster.py
+++ b/ecs/components/monster.py
@@ -9,3 +9,6 @@ class Monster:
     threat: List[int] = field(default_factory=lambda: [1])
     health: int = 1
     defend: int = 1
+
+    cur_threat: int = 0
+    max_threat: int = 0

--- a/ecs/processors/actualthreatprocessor.py
+++ b/ecs/processors/actualthreatprocessor.py
@@ -1,0 +1,28 @@
+from esper import Processor, World
+
+from constants import DijkstraMap
+from ecs.components.blinded import Blinded
+from ecs.components.map import Map
+from ecs.components.monster import Monster
+from ecs.components.player import Player
+from ecs.components.position import Position
+from ecs.components.visible import Visible
+
+
+class ActualThreatProcessor(Processor):
+    def process(self):
+        self.world: World
+
+        for _, game_map in self.world.get_component(Map):
+            for player_entity, player in self.world.get_component(Player):
+                for entity, (monster, _, position) in self.world.get_components(Monster, Visible, Position):
+                    distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
+                    in_range = 1 <= distance <= len(monster.threat)
+
+                    if in_range and not self.world.has_component(entity, Blinded):
+                        actual_threat = monster.threat[distance - 1]
+                        actual_threat = max(0, actual_threat - player.defend)
+                    else:
+                        actual_threat = 0
+
+                    monster.actual_threat = actual_threat

--- a/ecs/processors/actualthreatprocessor.py
+++ b/ecs/processors/actualthreatprocessor.py
@@ -14,7 +14,7 @@ class ActualThreatProcessor(Processor):
         self.world: World
 
         for _, game_map in self.world.get_component(Map):
-            for player_entity, player in self.world.get_component(Player):
+            for _, player in self.world.get_component(Player):
                 for entity, (monster, _, position) in self.world.get_components(Monster, Visible, Position):
                     distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
                     in_range = 1 <= distance <= len(monster.threat)

--- a/ecs/processors/defendaiprocessor.py
+++ b/ecs/processors/defendaiprocessor.py
@@ -58,10 +58,11 @@ class DefendAIProcessor(Processor):
                             if self.world.has_component(monster_entity, Boss):
                                 continue
 
-                            if monster.max_threat <= 0:
+                            if monster.visible_threat <= 0:
                                 continue
 
-                            candidates.append((monster.cur_threat, monster.max_threat, monster_entity, monster))
+                            candidate = (monster.actual_threat, monster.visible_threat, monster_entity, monster)
+                            candidates.append(candidate)
 
                         if candidates:
                             candidates.sort(reverse=True)

--- a/ecs/processors/defendaiprocessor.py
+++ b/ecs/processors/defendaiprocessor.py
@@ -55,12 +55,17 @@ class DefendAIProcessor(Processor):
                     for entity, (item, _, _) in self.world.get_components(Item, Inventory, FireScroll):
                         candidates = []
                         for monster_entity, (monster, _) in self.world.get_components(Monster, Visible):
-                            if not self.world.has_component(monster_entity, Boss):
-                                candidates.append((max(monster.threat), monster_entity, monster))
+                            if self.world.has_component(monster_entity, Boss):
+                                continue
+
+                            if monster.max_threat <= 0:
+                                continue
+
+                            candidates.append((monster.cur_threat, monster.max_threat, monster_entity, monster))
 
                         if candidates:
                             candidates.sort(reverse=True)
-                            _, monster_entity, monster = candidates[0]
+                            _, _, monster_entity, monster = candidates[0]
                             self.world.add_component(monster_entity, DefendTarget())
                             self.world.add_component(entity, DefendTarget())
                             player.defend_action = Action(

--- a/ecs/processors/gamestateprocessor.py
+++ b/ecs/processors/gamestateprocessor.py
@@ -4,6 +4,7 @@ from typing import List, Type
 from esper import Processor, World
 
 from ecs.components.gamestate import GameState
+from ecs.processors.actualthreatprocessor import ActualThreatProcessor
 from ecs.processors.rageprocessor import RageProcessor
 from ecs.processors.attackaiprocessor import AttackAIProcessor
 from ecs.processors.awakeprocessor import AwakeProcessor
@@ -23,11 +24,12 @@ from ecs.processors.playermapprocessor import PlayerMapProcessor
 from ecs.processors.spatialprocessor import SpatialProcessor
 from ecs.processors.stairmapprocessor import StairMapProcessor
 from ecs.processors.tauntedprocessor import TauntedProcessor
-from ecs.processors.threatprocessor import ThreatProcessor
+from ecs.processors.playerthreatprocessor import PlayerThreatProcessor
 from ecs.processors.trapprocessor import TrapProcessor
 from ecs.processors.useitemprocessor import UseItemProcessor
 from ecs.processors.usestairsprocessor import UseStairsProcessor
 from ecs.processors.visibilityprocessor import VisibilityProcessor
+from ecs.processors.visiblethreatprocessor import VisibleThreatProcessor
 from factories.world import make_world
 
 # Processors that run before user input
@@ -48,7 +50,9 @@ HI_PROCESSORS: List[Type[Processor]] = [
     StairMapProcessor,
 
     SpatialProcessor,
-    ThreatProcessor,
+    VisibleThreatProcessor,
+    ActualThreatProcessor,
+    PlayerThreatProcessor,
     TauntedProcessor,
 
     # Decide which options to give the player

--- a/ecs/processors/playerthreatprocessor.py
+++ b/ecs/processors/playerthreatprocessor.py
@@ -1,0 +1,23 @@
+from esper import Processor, World
+
+from constants import MAX_THREAT
+from ecs.components.map import Map
+from ecs.components.monster import Monster
+from ecs.components.player import Player
+
+
+class PlayerThreatProcessor(Processor):
+    def process(self):
+        self.world: World
+
+        for _, game_map in self.world.get_component(Map):
+            for player_entity, player in self.world.get_component(Player):
+                player.visible_threat = 0
+                player.actual_threat = 0
+
+                for entity, monster in self.world.get_component(Monster):
+                    player.visible_threat += monster.visible_threat
+                    player.actual_threat += monster.actual_threat
+
+                player.visible_threat = min(max(player.visible_threat, 0), MAX_THREAT)
+                player.actual_threat = min(max(player.actual_threat, 0), MAX_THREAT)

--- a/ecs/processors/spatialprocessor.py
+++ b/ecs/processors/spatialprocessor.py
@@ -19,12 +19,14 @@ class SpatialProcessor(Processor):
 
         for _, game_map in self.world.get_component(Map):
             for entity, position in self.world.get_component(Position):
-                if game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x] == 0:
+                distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
+
+                if distance == 0:
                     self.world.add_component(entity, Coincident())
                 elif self.world.has_component(entity, Coincident):
                     self.world.remove_component(entity, Coincident)
 
-                if game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x] == 1:
+                if distance == 1:
                     self.world.add_component(entity, Adjacent())
                 elif self.world.has_component(entity, Adjacent):
                     self.world.remove_component(entity, Adjacent)

--- a/ecs/processors/threatprocessor.py
+++ b/ecs/processors/threatprocessor.py
@@ -26,12 +26,18 @@ class ThreatProcessor(Processor):
                     if in_range or not self.world.has_component(entity, Assassin):
                         threat = max(monster.threat)
                         threat = max(0, threat - player.defend)
+                        monster.max_threat = threat
                         player.visible_threat += threat
+                    else:
+                        monster.max_threat = 0
 
                     if in_range and not self.world.has_component(entity, Blinded):
                         threat = monster.threat[distance - 1]
                         threat = max(0, threat - player.defend)
+                        monster.cur_threat = threat
                         player.actual_threat += threat
+                    else:
+                        monster.cur_threat = 0
 
                 player.visible_threat = min(max(player.visible_threat, 0), MAX_THREAT)
                 player.actual_threat = min(max(player.actual_threat, 0), MAX_THREAT)

--- a/ecs/processors/threatprocessor.py
+++ b/ecs/processors/threatprocessor.py
@@ -24,20 +24,22 @@ class ThreatProcessor(Processor):
                     in_range = 1 <= distance <= len(monster.threat)
 
                     if in_range or not self.world.has_component(entity, Assassin):
-                        threat = max(monster.threat)
-                        threat = max(0, threat - player.defend)
-                        monster.max_threat = threat
-                        player.visible_threat += threat
+                        visible_threat = max(monster.threat)
+                        visible_threat = max(0, visible_threat - player.defend)
                     else:
-                        monster.max_threat = 0
+                        visible_threat = 0
 
                     if in_range and not self.world.has_component(entity, Blinded):
-                        threat = monster.threat[distance - 1]
-                        threat = max(0, threat - player.defend)
-                        monster.cur_threat = threat
-                        player.actual_threat += threat
+                        actual_threat = monster.threat[distance - 1]
+                        actual_threat = max(0, actual_threat - player.defend)
                     else:
-                        monster.cur_threat = 0
+                        actual_threat = 0
+
+                    monster.visible_threat = visible_threat
+                    monster.actual_threat = actual_threat
+
+                    player.visible_threat += visible_threat
+                    player.actual_threat += actual_threat
 
                 player.visible_threat = min(max(player.visible_threat, 0), MAX_THREAT)
                 player.actual_threat = min(max(player.actual_threat, 0), MAX_THREAT)

--- a/ecs/processors/visiblethreatprocessor.py
+++ b/ecs/processors/visiblethreatprocessor.py
@@ -1,8 +1,7 @@
 from esper import Processor, World
 
-from constants import DijkstraMap, MAX_THREAT
+from constants import DijkstraMap
 from ecs.components.assassin import Assassin
-from ecs.components.blinded import Blinded
 from ecs.components.map import Map
 from ecs.components.monster import Monster
 from ecs.components.player import Player
@@ -10,15 +9,12 @@ from ecs.components.position import Position
 from ecs.components.visible import Visible
 
 
-class ThreatProcessor(Processor):
+class VisibleThreatProcessor(Processor):
     def process(self):
         self.world: World
 
         for _, game_map in self.world.get_component(Map):
             for player_entity, player in self.world.get_component(Player):
-                player.visible_threat = 0
-                player.actual_threat = 0
-
                 for entity, (monster, _, position) in self.world.get_components(Monster, Visible, Position):
                     distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
                     in_range = 1 <= distance <= len(monster.threat)
@@ -29,17 +25,4 @@ class ThreatProcessor(Processor):
                     else:
                         visible_threat = 0
 
-                    if in_range and not self.world.has_component(entity, Blinded):
-                        actual_threat = monster.threat[distance - 1]
-                        actual_threat = max(0, actual_threat - player.defend)
-                    else:
-                        actual_threat = 0
-
                     monster.visible_threat = visible_threat
-                    monster.actual_threat = actual_threat
-
-                    player.visible_threat += visible_threat
-                    player.actual_threat += actual_threat
-
-                player.visible_threat = min(max(player.visible_threat, 0), MAX_THREAT)
-                player.actual_threat = min(max(player.actual_threat, 0), MAX_THREAT)

--- a/ecs/processors/visiblethreatprocessor.py
+++ b/ecs/processors/visiblethreatprocessor.py
@@ -14,7 +14,7 @@ class VisibleThreatProcessor(Processor):
         self.world: World
 
         for _, game_map in self.world.get_component(Map):
-            for player_entity, player in self.world.get_component(Player):
+            for _, player in self.world.get_component(Player):
                 for entity, (monster, _, position) in self.world.get_components(Monster, Visible, Position):
                     distance = game_map.dijkstra[DijkstraMap.PLAYER][position.y][position.x]
                     in_range = 1 <= distance <= len(monster.threat)


### PR DESCRIPTION
Update fire scroll targeting to sort by actual threat descending, then by visible threat descending. This prioritises targets that can attack the player.